### PR TITLE
[fix] 최종본 레이아웃 수정

### DIFF
--- a/Mallery4/app/src/main/java/com/example/mallery4/DetailGroupFragment.kt
+++ b/Mallery4/app/src/main/java/com/example/mallery4/DetailGroupFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
@@ -38,6 +39,7 @@ class DetailGroupFragment (groupname: String, groupcount: String, groupid: Long,
     //recycycler view list
     val PostItemList= arrayListOf<PostItem>()
 
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -49,6 +51,7 @@ class DetailGroupFragment (groupname: String, groupcount: String, groupid: Long,
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
 
         // 앞에서 클릭한 해당 detail group 정보로 화면 띄우기
         de_groupname.setText(group_name)

--- a/Mallery4/app/src/main/res/drawable/ic_baseline_keyboard_arrow_left_24.xml
+++ b/Mallery4/app/src/main/res/drawable/ic_baseline_keyboard_arrow_left_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#776664" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M15.41,16.59L10.83,12l4.58,-4.59L14,6l-6,6 6,6 1.41,-1.41z"/>
+</vector>

--- a/Mallery4/app/src/main/res/drawable/ic_baseline_keyboard_arrow_right_24.xml
+++ b/Mallery4/app/src/main/res/drawable/ic_baseline_keyboard_arrow_right_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#776664" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M8.59,16.59L13.17,12 8.59,7.41 10,6l6,6 -6,6 -1.41,-1.41z"/>
+</vector>

--- a/Mallery4/app/src/main/res/layout/activity_login.xml
+++ b/Mallery4/app/src/main/res/layout/activity_login.xml
@@ -17,16 +17,26 @@ tools:context=".LoginActivity">
     android:layout_marginBottom="8dp"
     android:src="@drawable/logo" />
 
-<TextView
-    android:id="@+id/logo_txt"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:layout_marginTop="10dp"
-    android:layout_marginBottom="10dp"
-    android:text="@string/login_logo"
-    android:textColor="@color/browncolor"
-    android:textSize="25dp" />
+    <TextView
+        android:id="@+id/logo_txt"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:text="@string/login_logo"
+        android:textColor="@color/browncolor"
+        android:textSize="25dp" />
+    <TextView
+        android:id="@+id/logo_txt2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:text="@string/login_logo2"
+        android:textColor="@color/browncolor"
+        android:textSize="25dp" />
 
     <EditText
         android:id="@+id/login_id"

--- a/Mallery4/app/src/main/res/layout/activity_signup.xml
+++ b/Mallery4/app/src/main/res/layout/activity_signup.xml
@@ -14,17 +14,29 @@
         android:id="@+id/logo_img"
         android:layout_width="match_parent"
         android:layout_height="200dp"
+        android:layout_gravity="center"
+        android:gravity="center"
         android:layout_marginBottom="8dp"
-        android:src="@drawable/deco" />
+        android:src="@drawable/logo" />
 
     <TextView
         android:id="@+id/logo_txt"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp"
+        android:gravity="center"
+        android:textAlignment="center"
         android:text="@string/login_logo"
+        android:textColor="@color/browncolor"
+        android:textSize="25dp" />
+    <TextView
+        android:id="@+id/logo_txt2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:text="@string/login_logo2"
         android:textColor="@color/browncolor"
         android:textSize="25dp" />
 

--- a/Mallery4/app/src/main/res/layout/fragment_add_friend.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_add_friend.xml
@@ -54,8 +54,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:layout_marginTop="30dp"
-        android:layout_marginLeft="20dp"
-        android:layout_marginRight="20dp">
+        android:layout_marginLeft="20dp">
 
         <EditText
             android:id="@+id/fri_id"
@@ -66,16 +65,15 @@
             android:background="@drawable/enroll_edittext_style"
             android:textColorHint="@color/browncolor"
             android:textSize="18dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/fri_check"
-            android:layout_width="80dp"
+            android:layout_width="60dp"
+            android:layout_marginLeft="4dp"
+            android:layout_marginRight="10dp"
+            android:padding="2dp"
             android:layout_height="45dp"
-            android:layout_gravity="right"
+            android:layout_gravity="center"
             android:background="@drawable/rounded_pink"
             android:text="확인"
             android:textSize="12dp"

--- a/Mallery4/app/src/main/res/layout/fragment_change_album_name.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_change_album_name.xml
@@ -39,19 +39,19 @@
         android:textColorHint="@color/browncolor"
         android:textSize="18dp" />
 
-
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:layout_gravity="center"
-        android:layout_marginTop="100dp"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp">
-
+        android:layout_marginBottom="15dp">
         <androidx.appcompat.widget.AppCompatButton
-            android:layout_margin="20dp"
+            android:layout_weight="1"
             android:id="@+id/nch_name"
             android:layout_width="150dp"
             android:layout_height="wrap_content"
@@ -59,10 +59,11 @@
             android:text="변경취소"
             android:textStyle="bold"
             android:textSize="20dp"
+            android:layout_margin="8dp"
             android:textColor="@color/browncolor"/>
 
         <androidx.appcompat.widget.AppCompatButton
-            android:layout_margin="20dp"
+            android:layout_weight="1"
             android:id="@+id/ch_name"
             android:layout_width="150dp"
             android:layout_height="wrap_content"
@@ -70,8 +71,8 @@
             android:text="변경하기"
             android:textStyle="bold"
             android:textSize="20dp"
+            android:layout_margin="8dp"
             android:textColor="@color/browncolor"/>
-
     </LinearLayout>
 
 </LinearLayout>

--- a/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
@@ -101,11 +101,14 @@
             android:id="@+id/add_post"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
             android:layout_alignParentEnd="true"
-            android:src="@drawable/ic_baseline_add_24"
+            android:layout_alignParentBottom="true"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
             android:backgroundTint="@color/pointcolor"
             android:contentDescription="new_post"
-            android:layout_margin="16dp" />
+            android:src="@drawable/ic_baseline_add_24" />
     </RelativeLayout>
 </LinearLayout>

--- a/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
@@ -14,10 +14,11 @@
 
         <ImageButton
             android:id="@+id/btn_home_backhome"
-            android:layout_width="wrap_content"
+            android:layout_width="20dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="2dp"
             android:layout_height="50dp"
             android:layout_marginTop="12dp"
-            android:layout_weight="1"
             android:background="@color/background"
             android:src="@drawable/ic_baseline_arrow_back_24" />
 
@@ -56,7 +57,7 @@
             android:layout_height="wrap_content"
             android:text="3"
             android:textSize="21dp"
-            android:layout_marginLeft="35dp"
+            android:layout_marginLeft="32dp"
             android:textColor="#766563" />
 
         <TextView

--- a/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
@@ -14,7 +14,7 @@
 
         <ImageButton
             android:id="@+id/btn_home_backhome"
-            android:layout_width="40dp"
+            android:layout_width="wrap_content"
             android:layout_height="50dp"
             android:layout_marginTop="12dp"
             android:layout_weight="1"
@@ -56,7 +56,7 @@
             android:layout_height="wrap_content"
             android:text="3"
             android:textSize="21dp"
-            android:layout_marginLeft="48dp"
+            android:layout_marginLeft="35dp"
             android:textColor="#766563" />
 
         <TextView
@@ -99,7 +99,9 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/grid_rv"
             android:layout_centerHorizontal="true"
-            android:layout_width="wrap_content"
+            android:layout_marginLeft="3dp"
+            android:layout_marginRight="3dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:listitem="@layout/grid_items" />
 

--- a/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_detail_group.xml
@@ -29,7 +29,6 @@
         android:textSize="25dp"
         android:textStyle="bold"
         android:textColor="#766563"
-        android:layout_marginLeft="8dp"
         android:layout_weight="8"
         android:layout_marginTop="20dp" />
 
@@ -47,7 +46,7 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
         android:orientation="horizontal"
         android:layout_marginTop="18dp"
         android:layout_marginBottom="20dp">
@@ -55,11 +54,18 @@
             android:id="@+id/de_cnt"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="3명"
-            android:textSize="15dp"
-            android:layout_marginLeft="38dp"
-            android:layout_weight="10"
+            android:text="3"
+            android:textSize="21dp"
+            android:layout_marginLeft="48dp"
             android:textColor="#766563" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="명"
+            android:layout_weight="10"
+            android:textColor="#766563"
+            android:textSize="21dp" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/ch_nick"

--- a/Mallery4/app/src/main/res/layout/fragment_detail_post.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_detail_post.xml
@@ -22,10 +22,11 @@
 
                 <ImageButton
                     android:id="@+id/btn_detail_group_backhome"
-                    android:layout_marginTop="10dp"
-                    android:layout_width="40dp"
+                    android:layout_width="20dp"
                     android:layout_height="50dp"
-                    android:layout_weight="1"
+                    android:layout_marginLeft="10dp"
+                    android:layout_marginRight="2dp"
+                    android:layout_marginTop="12dp"
                     android:src="@drawable/ic_baseline_arrow_back_24"
                     android:background="@color/background" />
 
@@ -33,64 +34,73 @@
                     android:id="@+id/post_date"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="18dp"
+                    android:layout_marginTop="14.5dp"
                     android:text="0000년 00월 00일"
                     android:textSize="24dp"
                     android:textStyle="bold"
-                    android:layout_weight="10"
-                    android:layout_marginLeft="8dp"
+                    android:layout_weight="14"
                     android:textColor="#766563" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text=""
-                    android:textSize="15dp"
-                    android:layout_marginLeft="38dp"
-                    android:layout_weight="10"
-                    android:textColor="#766563" />
-
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/del_post"
-                    android:layout_width="85dp"
-                    android:layout_height="25dp"
-                    android:background="@drawable/rounded_pink"
-                    android:text="삭제하기"
-                    android:textStyle="bold"
-                    android:textSize="10dp"
-                    android:layout_weight="1"
-                    android:layout_marginRight="10dp"
-                    android:textColor="@color/browncolor"/>
-            </LinearLayout>
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@color/background"
+                    android:stateListAnimator="@null"
+                    android:textColor="@color/browncolor"
+                    android:layout_marginTop="14dp"
+                    android:text="@string/del_btn"
+                    android:textSize="18dp"
+                    android:layout_weight="2"/>
 
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/post_viewpager"
-                android:layout_margin="28dp"
-                android:layout_width="match_parent"
-                android:layout_height="300dp"/>
+            </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_marginTop="28dp"
+                    android:layout_width="wrap_content"
+                    android:layout_weight="2"
+                    android:layout_height="300dp"
+                    android:src="@drawable/ic_baseline_keyboard_arrow_left_24"/>
+
+                <androidx.viewpager2.widget.ViewPager2
+                    android:id="@+id/post_viewpager"
+                    android:layout_marginTop="28dp"
+                    android:layout_weight="10"
+                    android:layout_width="wrap_content"
+                    android:layout_height="300dp"/>
+
+                <ImageView
+                    android:layout_marginTop="28dp"
+                    android:layout_width="wrap_content"
+                    android:layout_weight="2"
+                    android:layout_height="300dp"
+                    android:src="@drawable/ic_baseline_keyboard_arrow_right_24"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="5dp">
                 <ImageView
                     android:layout_width="30dp"
                     android:layout_height="30dp"
                     android:src="@drawable/ic_baseline_location_on_24"
                     android:layout_marginLeft="38dp"
                     android:textColor="#766563" />
+
                 <TextView
                     android:id="@+id/post_destination"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="post할 때 쓴 장소"
-                    android:textSize="20dp"
+                    android:textSize="15dp"
+                    android:layout_marginTop="5dp"
                     android:gravity="center"
                     android:layout_marginLeft="8dp"
                     android:textColor="#766563" />
@@ -111,7 +121,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="함께한 멤버들"
-                    android:textSize="20dp"
+                    android:textSize="15dp"
+                    android:layout_marginTop="5dp"
                     android:gravity="center"
                     android:layout_marginLeft="8dp"
                     android:textColor="#766563" />

--- a/Mallery4/app/src/main/res/layout/fragment_home.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_home.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -16,22 +17,11 @@
         android:textColor="#766563"
         android:gravity="center"/>
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btn_makegroup"
-        android:layout_width="120dp"
-        android:layout_height="40dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginLeft="250dp"
-        android:background="@drawable/rounded_pink"
-        android:text="그룹 만들기"
-        android:textStyle="bold"
-        android:textSize="18dp"
-        android:textColor="@color/browncolor"/>
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:layout_marginTop="20dp"
         android:layout_marginBottom="20dp">
         <TextView
             android:id="@+id/home_nickname"
@@ -46,17 +36,39 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text=" 님의 그룹"
+            android:text="님의 그룹"
             android:textSize="25dp"
             android:textColor="#766563" />
     </LinearLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/list_rv"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="15dp"
-        tools:listitem="@layout/main_items">
-    </androidx.recyclerview.widget.RecyclerView>
+        android:layout_height="match_parent">
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/list_rv"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="28dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginEnd="28dp"
+            tools:listitem="@layout/main_items"></androidx.recyclerview.widget.RecyclerView>
+
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/btn_makegroup"
+            android:layout_width="151dp"
+            android:layout_height="53dp"
+            android:gravity="center"
+            android:textAlignment="center"
+            android:layout_marginBottom="20dp"
+            android:layout_centerHorizontal="true"
+            android:layout_alignParentBottom="true"
+            android:text=" 그룹만들기"
+            android:textStyle="bold"
+            android:textSize="20dp"
+            android:textColor="@color/browncolor"
+            android:backgroundTint="@color/pointcolor"
+            android:contentDescription="new_group"
+            app:shapeAppearanceOverlay="?attr/shapeAppearanceMediumComponent"/>
+    </RelativeLayout>
 </LinearLayout>

--- a/Mallery4/app/src/main/res/layout/fragment_mypage.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_mypage.xml
@@ -16,16 +16,10 @@
         android:textColor="#766563"
         android:gravity="center"/>
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/logout_btn"
+    <TextView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="300dp"
-        android:background="@color/background"
-        android:stateListAnimator="@null"
-        android:text="로그아웃"
-        android:textColor="@color/browncolor"
-        android:textSize="14dp" />
+        android:layout_height="40dp"
+        android:text="" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -36,15 +30,14 @@
             android:layout_weight="1.5"
             android:layout_height="wrap_content"
             android:text=""
-            android:textSize="40dp"
+            android:textSize="30dp"
             android:textColor="#766563" />
         <TextView
             android:id="@+id/mypage_nickname"
-            android:layout_width="0px"
-            android:layout_weight="1.5"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="닉네임"
-            android:textSize="25dp"
+            android:textSize="30dp"
             android:textStyle="bold"
             android:gravity="center"
             android:textColor="#766563" />
@@ -60,7 +53,7 @@
             android:layout_weight="1.5"
             android:layout_height="wrap_content"
             android:text=""
-            android:textSize="40dp"
+            android:textSize="30dp"
             android:gravity="left"
             android:textColor="#766563" />
     </LinearLayout>
@@ -119,15 +112,27 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/change_btn"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        android:layout_marginLeft="70dp"
-        android:layout_marginRight="70dp"
+        android:layout_width="151dp"
+        android:layout_height="53dp"
+        android:layout_marginTop="80dp"
+        android:layout_gravity="center"
         android:background="@drawable/rounded_pink"
         android:text="변경하기"
         android:textStyle="bold"
         android:textSize="20dp"
         android:textColor="@color/browncolor"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/logout_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:layout_marginLeft="100dp"
+        android:layout_marginRight="100dp"
+        android:background="@color/background"
+        android:stateListAnimator="@null"
+        android:text="@string/logout_btn"
+        android:textColor="@color/browncolor"
+        android:textSize="18dp" />
 
 </LinearLayout>

--- a/Mallery4/app/src/main/res/layout/fragment_mypage2.xml
+++ b/Mallery4/app/src/main/res/layout/fragment_mypage2.xml
@@ -30,19 +30,17 @@
             android:layout_weight="1.5"
             android:layout_height="wrap_content"
             android:text=""
-            android:textSize="40dp"
+            android:textSize="30dp"
             android:textColor="#766563" />
         <TextView
             android:id="@+id/mypage2_nickname"
-            android:layout_width="0px"
-            android:layout_weight="1.5"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="닉네임"
-            android:textSize="25dp"
+            android:textSize="30dp"
             android:textStyle="bold"
             android:gravity="center"
             android:textColor="#766563" />
-
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -54,7 +52,7 @@
             android:layout_weight="1.5"
             android:layout_height="wrap_content"
             android:text=""
-            android:textSize="40dp"
+            android:textSize="30dp"
             android:gravity="left"
             android:textColor="#766563" />
     </LinearLayout>
@@ -112,13 +110,12 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/change2_btn"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        android:layout_marginLeft="70dp"
-        android:layout_marginRight="70dp"
+        android:layout_width="151dp"
+        android:layout_height="53dp"
+        android:layout_marginTop="80dp"
+        android:layout_gravity="center"
         android:background="@drawable/rounded_pink"
-        android:text="변경완료"
+        android:text="변경"
         android:textStyle="bold"
         android:textSize="20dp"
         android:textColor="@color/browncolor"/>

--- a/Mallery4/app/src/main/res/layout/grid_items.xml
+++ b/Mallery4/app/src/main/res/layout/grid_items.xml
@@ -1,36 +1,40 @@
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/constraint"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:orientation="vertical">
 
-    <ImageView
-        android:id="@+id/gridImg"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:contentDescription="사진"
-        app:layout_constraintDimensionRatio="397:596"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@mipmap/ic_launcher" />
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        app:cardCornerRadius="15dp"
+        android:layout_margin="8dp">
+
+        <ImageView
+            android:id="@+id/gridImg"
+            android:layout_width="match_parent"
+            android:layout_height="262.5dp"
+            android:adjustViewBounds="true"
+            android:layout_gravity="center"
+            android:scaleType="centerCrop"
+            android:contentDescription="사진"
+            app:srcCompat="@mipmap/ic_launcher" />
+    </androidx.cardview.widget.CardView>
+
 
     <TextView
         android:id="@+id/postdate"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:textSize="20dp"
+        android:layout_marginEnd="3dp"
+        android:layout_marginStart="3dp"
+        android:layout_marginTop="3dp"
+        android:textSize="18dp"
         android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/gridImg"
+        android:layout_gravity="center"
         tools:text="0000년 00월 00일" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/Mallery4/app/src/main/res/layout/main_items.xml
+++ b/Mallery4/app/src/main/res/layout/main_items.xml
@@ -26,17 +26,24 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="졸업프로젝트 14팀"
-            android:textSize="20dp"
+            android:textSize="23dp"
             android:textStyle="bold"
             android:layout_weight="4"
-            android:layout_marginLeft="38dp"
+            android:layout_marginLeft="18dp"
             android:textColor="#766563" />
 
             <TextView
                 android:id="@+id/gp_cnt"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="3명"
+                android:text="3"
+                android:textColor="#766563"
+                android:textSize="15dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="명"
                 android:layout_weight="1"
                 android:textColor="#766563"
                 android:textSize="15dp" />
@@ -46,7 +53,7 @@
             android:id="@+id/gp_nicknames"
             android:layout_marginTop="18dp"
             android:layout_marginBottom="20dp"
-            android:layout_marginLeft="38dp"
+            android:layout_marginLeft="18dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="nicknames"

--- a/Mallery4/app/src/main/res/layout/main_items.xml
+++ b/Mallery4/app/src/main/res/layout/main_items.xml
@@ -28,7 +28,7 @@
             android:text="졸업프로젝트 14팀"
             android:textSize="23dp"
             android:textStyle="bold"
-            android:layout_weight="4"
+            android:layout_weight="12"
             android:layout_marginLeft="18dp"
             android:textColor="#766563" />
 
@@ -58,7 +58,6 @@
             android:layout_height="wrap_content"
             android:text="nicknames"
             android:textSize="15dp"
-            android:gravity="center"
             android:textColor="#766563" />
     </LinearLayout>
 

--- a/Mallery4/app/src/main/res/layout/postview_items.xml
+++ b/Mallery4/app/src/main/res/layout/postview_items.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/background">
 
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        app:cardCornerRadius="15dp"
+        android:layout_margin="8dp">
     <ImageView
         android:id="@+id/postView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:layout_gravity="center"
+        android:scaleType="centerCrop"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
+    </androidx.cardview.widget.CardView>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/Mallery4/app/src/main/res/values/strings.xml
+++ b/Mallery4/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="login_logo2"><i>for friends</i></string>
     <string name="signup_style"><u>회원가입</u></string>
     <string name="logout_btn"><u>로그아웃</u></string>
+    <string name="del_btn"><u>삭제하기</u></string>
     <string name="delete_group"><u>탈퇴하기</u></string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
 

--- a/Mallery4/app/src/main/res/values/strings.xml
+++ b/Mallery4/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="login_logo"><i>Memory &amp; Gallery</i></string>
     <string name="login_logo2"><i>for friends</i></string>
     <string name="signup_style"><u>회원가입</u></string>
+    <string name="logout_btn"><u>로그아웃</u></string>
     <string name="delete_group"><u>탈퇴하기</u></string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
 

--- a/Mallery4/app/src/main/res/values/strings.xml
+++ b/Mallery4/app/src/main/res/values/strings.xml
@@ -1,7 +1,8 @@
 <resources>
     <string name="app_name">Mallery4</string>
 
-    <string name="login_logo"><b><i>Memory &amp; Gallery \n        for friends</i></b></string>
+    <string name="login_logo"><i>Memory &amp; Gallery</i></string>
+    <string name="login_logo2"><i>for friends</i></string>
     <string name="signup_style"><u>회원가입</u></string>
     <string name="delete_group"><u>탈퇴하기</u></string>
     <string name="hello_blank_fragment">Hello blank fragment</string>


### PR DESCRIPTION
- [x] 회원가입 이미지 (곰돌이 -> 앱로고사진으로)
- [x] 로그인/ 회원가입페이지 : 글씨 가운데 정렬 ( Memory~)
- [x] 마이페이지 : 사용자 이름 크기 좀 크게 + 님이랑 붙이기
- [x] 로그아웃 변경하기 버튼 아래로 + 로그아웃 버튼 밑줄형식으로 바꾸기 텍스트 스타일
- [x] 변경하기 버튼 가로길이를 좀 줄이기
- [x] 홈화면: 리사이클러뷰 가로사이즈 시작과 닉네임 시작 간격 맞추기
- [x] 리사이클러뷰 안에 그룹 이름 글씨 크기 키우기
- [x] 리사이클러뷰 안에 그룹 안에 있는 인원수 아예 옆으로 + 0명 이렇게 명 붙여써주기
- [x] (그룹만들기 버튼 플로팅으로 처리할 수 있으면 처리)
- [x] 세부그룹 선택(1) : 명수 글씨 키우기 + 명 붙여주기
- [x] 세부그룹 앨범명 왼쪽으로 붙이고, 이거에 맞춰서 사진 간 여백(맨왼/맨오른) 줄이기
- [x] (+) 사진 테두리 둥글게
- [x] 세부게시글 선택: 삭제하기 버튼 탈퇴하기처럼 밑줄처리 + 날짜 옆에 한줄로
- [x] (+) 사진 테두리 둥글게
- [x] 사진 크기를 일정한 사이즈로(wid, hei)
- [x] 사진 양옆에 < >  기호 써줄 수 있으면 써주기
- [x] 위치/사람 글씨 사이즈 줄이기